### PR TITLE
fix: remove hard-coded AVX2 target feature for x86_64

### DIFF
--- a/packages/bigint-buffer2/.cargo/config.toml
+++ b/packages/bigint-buffer2/.cargo/config.toml
@@ -1,14 +1,15 @@
-# Enable SIMD and advanced CPU features for performance
-# This provides 10-30% improvement for vectorizable operations
-
-[target.x86_64-unknown-linux-gnu]
-rustflags = ["-C", "target-feature=+avx2,+bmi2"]
-
-[target.x86_64-apple-darwin]
-rustflags = ["-C", "target-feature=+avx2,+bmi2"]
+# CPU feature configuration for native builds
+#
+# x86_64: Build for baseline x86-64 (SSE2) to ensure portability across all
+# x86_64 CPUs, including Intel Atom/Celeron/Pentium without AVX support.
+# The compiler will still auto-vectorize with SSE2 where beneficial.
+#
+# aarch64: Enable crypto extensions (AES, SHA2) which are baseline on
+# Apple Silicon (M1+) and most modern ARM64 Linux targets.
+#
+# See: https://github.com/vekexasia/bigint-swissknife/issues/6
 
 [target.aarch64-apple-darwin]
-# M1/M2 Macs - NEON is enabled by default, add crypto extensions
 rustflags = ["-C", "target-feature=+aes,+sha2"]
 
 [target.aarch64-unknown-linux-gnu]


### PR DESCRIPTION
## Problem

The `.cargo/config.toml` sets `rustflags = ["-C", "target-feature=+avx2,+bmi2"]` for x86_64 targets, forcing the Rust compiler to emit AVX2/BMI2 instructions unconditionally. This causes the prebuilt native binary to crash with **SIGILL (exit code 132)** on any x86_64 CPU without AVX2 support.

Affected CPUs include:
- Intel Celeron / Atom / Pentium (Jasper Lake, Gemini Lake, etc.)
- Intel Core pre-Haswell (before 4th gen)
- Various low-power and embedded x86_64 processors

## Fix

Remove the `+avx2,+bmi2` target features for x86_64 targets. The Rust code does not use explicit AVX intrinsics — the AVX2 instructions come entirely from compiler auto-vectorization forced by the flag. Building for baseline x86-64 (SSE2) still allows auto-vectorization with SSE2 where beneficial.

aarch64 targets retain `+aes,+sha2` since these are baseline on Apple Silicon and modern ARM64 Linux.

## Impact

Downstream project [ChainSafe/lodestar](https://github.com/ChainSafe/lodestar) (Ethereum consensus client) depends on `@vekexasia/bigint-buffer2`. A user running on a Celeron N5105 reported the crash: [ChainSafe/lodestar#9042](https://github.com/ChainSafe/lodestar/issues/9042).

Analysis confirmed the native binary has **1292 AVX instructions and 0 CPUID-based dispatch calls** — the only native dependency in Lodestar's tree without proper runtime CPU detection.

Fixes #6